### PR TITLE
fix: initial cursor offset

### DIFF
--- a/addons/awesome_custom_cursor/Autoloads/Cursor.gd
+++ b/addons/awesome_custom_cursor/Autoloads/Cursor.gd
@@ -31,8 +31,8 @@ enum Shapes {
 @onready var previous_mouse_shape: int = Input.get_current_cursor_shape()
 
 var shape: int = Input.CURSOR_ARROW: set = set_shape
-var current_animation: StringName
-var current_frame_texture: Texture2D
+@onready var current_animation: StringName = sprite.animation
+@onready var current_frame_texture: Texture2D = sprite.sprite_frames.get_frame_texture(current_animation, sprite.frame)
 
 func _ready():
 	sprite.hide()


### PR DESCRIPTION
Fixes an issue with initializing the cursor offset.

Had an issue where my first click would 'teleport' my mouse cursor. Figured out it was due to the offset not being set in the ready step, and I was setting my default cursor within `_ready`.

This small change fixed it for me.

(I was in Godot 4.3, if that matters.)